### PR TITLE
Fix Output-Input Format Mismatch Between fold and eval

### DIFF
--- a/src/LinearFold.cpp
+++ b/src/LinearFold.cpp
@@ -2012,10 +2012,12 @@ int main(int argc, char** argv){
                 if (ref.length() == 0) {
                     continue;
                 }
-		
+
+		// If input is LinearFold, Remove energy term (e.g., "(-xxx.xx)")
+		// to ensure compatibility with eval function.
 		size_t space_pos = ref.find_last_of(' ');
 		if (space_pos != string::npos) {
-		    ref = ref.substr(0, space_pos);
+		    ref = ref.substr(0, space_pos); // Trim energy term.
 		}
 	
                 if ((ref[0] != '.') && (ref[0] != '(') && (ref[0] != ')')) {

--- a/src/LinearFold.cpp
+++ b/src/LinearFold.cpp
@@ -2012,8 +2012,13 @@ int main(int argc, char** argv){
                 if (ref.length() == 0) {
                     continue;
                 }
-
-                else if ((ref[0] != '.') && (ref[0] != '(') && (ref[0] != ')')) {
+		
+		size_t space_pos = ref.find_last_of(' ');
+		if (space_pos != string::npos) {
+		    ref = ref.substr(0, space_pos);
+		}
+	
+                if ((ref[0] != '.') && (ref[0] != '(') && (ref[0] != ')')) {
                     printf("Unrecognized structure: %s\n", ref.c_str());
                     return 0;
                 }
@@ -2039,7 +2044,7 @@ int main(int argc, char** argv){
                 // call eval function;
                 double MFE_energy = eval(seq, ref, is_verbose, dangles) / -100.0;
                 printf("%s\n", seq.c_str());
-                printf("%s (%.2f)\n", input.c_str(), MFE_energy);
+                printf("%s (%.2f)\n", ref.c_str(), MFE_energy);
 
             }
             lineIndex ++;


### PR DESCRIPTION
When fold is called before eval, its output includes an energy value at the end of the structure line, causing eval to misinterpret the input. This fix removes the trailing energy value by detecting and trimming the last space in ref, ensuring proper format consistency between fold and eval.